### PR TITLE
quickfix_genomeDEGSfiles

### DIFF
--- a/R/calculateDEGS_functions.R
+++ b/R/calculateDEGS_functions.R
@@ -17,8 +17,8 @@ DEGS_scANANSE <- function(seurat_object,
                           output_dir,
                           min_cells = 50,
                           cluster_id = 'seurat_clusters',
-                          RNA_count_assay = "RNA",
                           genome = './scANANSE/data/hg38',
+                          RNA_count_assay = "RNA",
                           additional_contrasts = 'None') {
   if (missing(output_dir)) {
     warning('no output_dir specified')

--- a/R/calculateDEGS_functions.R
+++ b/R/calculateDEGS_functions.R
@@ -18,6 +18,7 @@ DEGS_scANANSE <- function(seurat_object,
                           min_cells = 50,
                           cluster_id = 'seurat_clusters',
                           RNA_count_assay = "RNA",
+                          genome = './scANANSE/data/hg38',
                           additional_contrasts = 'None') {
   if (missing(output_dir)) {
     warning('no output_dir specified')
@@ -55,7 +56,8 @@ DEGS_scANANSE <- function(seurat_object,
       paste0(
         output_dir,
         '/deseq2/',
-        'hg38-anansesnake_',
+		basename(genome),
+        '-anansesnake_',
         comparison1,
         '_',
         comparison2,

--- a/man/DEGS_scANANSE.Rd
+++ b/man/DEGS_scANANSE.Rd
@@ -9,6 +9,7 @@ DEGS_scANANSE(
   output_dir,
   min_cells = 50,
   cluster_id = "seurat_clusters",
+  genome = "./scANANSE/data/hg38",
   RNA_count_assay = "RNA",
   additional_contrasts = "None"
 )
@@ -21,6 +22,8 @@ DEGS_scANANSE(
 \item{min_cells}{minimum of cells a cluster needs to be exported}
 
 \item{cluster_id}{ID used for finding clusters of cells}
+
+\item{genome}{genomepy name or location of the genome fastq file}
 
 \item{RNA_count_assay}{assay containing the RNA data}
 


### PR DESCRIPTION
A quick fix to the assembly name in DEGS files run with `DEGS_scANANSE()` (see #27)

Added a argument `genome` to the function.